### PR TITLE
Updates application to use PostgreSQL and removes sqlite3 from Gem file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,7 @@ end
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.1'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     nio4r (2.0.0)
     nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
+    pg (0.20.0)
     public_suffix (2.0.5)
     puma (3.8.2)
     rack (2.0.3)
@@ -151,7 +152,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -179,12 +179,12 @@ DEPENDENCIES
   capybara (~> 2.13)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  pg
   puma (~> 3.7)
   rails (~> 5.1.1)
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   selenium-webdriver
-  sqlite3
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
@@ -193,4 +193,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,22 +4,20 @@
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
 #
-default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+development:
+  adapter: postgresql
+  database: acebook_development
+  pool: 5
   timeout: 5000
 
-development:
-  <<: *default
-  database: db/development.sqlite3
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: db/test.sqlite3
+  adapter: postgresql
+  database: acebook_test
+  pool: 5
+  timeout: 5000
 
 production:
-  <<: *default
-  database: db/production.sqlite3
+  adapter: postgresql
+  database: acebook_production
+  pool: 5
+  timeout: 5000

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,9 @@
 
 ActiveRecord::Schema.define(version: 20170526114520) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "posts", force: :cascade do |t|
     t.string "message"
     t.datetime "created_at", null: false


### PR DESCRIPTION
Chris and I have learned that sqlite3 isn't supported by Heroku. The recommended work around is to use PostgreSQL as development and production(test also if needed) database choice. Quick reading suggests it is compatible with ActiveRecord, so it should be a straight swap.

Could two pairs (i.e 4 individuals) please look at shipping the code below? We can't deploy the app to Heroku from a branch until the pull request is merged into master.

See here for more info:
https://devcenter.heroku.com/articles/sqlite3

Please note, we will give further instruction on migrating the PostgreSQL databases across the cohort once merged.

Thank you in advance! :shipit: