### PR TITLE
Broken image link fix for production app.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@
 /yarn-error.log
 
 .byebug_history
-public/system/
+public/system/photos/images


### PR DESCRIPTION
An attempt to solve the problem with image links at `/photos` breaking after a while.